### PR TITLE
brew-cask自体のインストールを削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+brew_info
+cask_info
+hosts

--- a/localhost.yml
+++ b/localhost.yml
@@ -85,9 +85,6 @@
       shell: brew info {{ item }} > brew_info/{{ item }}
       with_items: brew_result.results | selectattr('changed') | map(attribute='item') | map(attribute='name') | list
 
-    - name: install homebrew-cask
-      homebrew: name=brew-cask state=latest
-
     - name: install cask packages
       homebrew_cask: name={{ item.name }} state={{ item.state | default('present') }}
       with_items: homebrew_cask_packages


### PR DESCRIPTION
homebrew-cask自体のインストールが不要だった(むしろコケる)のでplaybookからtaskを削除しました。
また、`start.sh` で動的に生成してるhostsとインストール時の情報を格納すると思われる下記のディレクトリを管理対象から外しました。
- brew_info
- cask_info
